### PR TITLE
Directly use ds-metadata-values component to avoid browse definition …

### DIFF
--- a/src/themes/capstone/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/themes/capstone/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -59,11 +59,16 @@
   </div>
   <div class="col-xs-12 col-md-6">
     <!--TAMU Customization - Display Sponsors-->
-    <ds-generic-item-page-field [item]="object"
-      [fields]="['dc.contributor.sponsor']"
-      [separator]="', '"
-      [label]="'relationships.isSponsorOf' | translate">
-    </ds-generic-item-page-field>
+    <div class="item-page-field">
+      <ds-metadata-values
+        [mdValues]="object?.allMetadata(['dc.contributor.sponsor'])"
+        [separator]="', '"
+        [label]="'relationships.isSponsorOf'"
+        [enableMarkdown]="'false'"
+        [urlRegex]="'false'"
+        [browseDefinition]="">
+      </ds-metadata-values>
+    </div>
     <!--End TAMU Customization - Display Sponsors-->
     <ds-item-page-abstract-field [item]="object"></ds-item-page-abstract-field>
     <ds-generic-item-page-field [item]="object"


### PR DESCRIPTION
…check

`dc.contributor.sponsor` falls under `ValueListBrowseDefinition` within `dc.contributor.*` causing the generic item page field to render as a browse definition link.

## References
Resolves #3 

## Description
`ds-generic-item-page-field` component conditionally renders metadata values differently based on inputs and whether the metadata fields provided are within backend defined value list browse definition. Which pending the async response, will render the metadata values as a link to browse results starting with the value. In the case of ` Client/sponsor field` we do not want it to be a link, but a comma separated list.

Using directly the `ds-metadata-values` and specifying the `browseDefinition` input to be undefined provides the simple metadata value rendering.

## Instructions for Reviewers

From this branch, update config to labs DSpace REST API as follows.

```
rest:
  ssl: true
  host: api-dev.library.tamu.edu
  port: 443
  nameSpace: /dspace7
```

Start in development mode.

```
yarn start:dev
```

Navigate to an item within the Capstone Project.

http://localhost:4000/items/67eafadf-d5b3-4962-b425-9d3f5bc128db

Check to make sure the `Client` metadata field is not a link.

![image](https://github.com/TAMULib/dspace-angular/assets/144841721/18193e4c-a5bd-4726-bb09-c0eb92d7b537)

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods. 
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
