### PR TITLE
Enable media viewer by default

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -4,6 +4,10 @@ rest:
   port: 443
   nameSpace: /server
 
+mediaViewer:
+  image: true
+  video: false
+
 themes:
   - name: capstone
     extends: tamu


### PR DESCRIPTION
## Description
Enable media viewer by default. This is a configuration that does not support override by environment variable.
