### PR TITLE
Add UI nameSpace context path to Mirador viewer path

### DIFF
--- a/src/app/item-page/mirador-viewer/mirador-viewer.component.ts
+++ b/src/app/item-page/mirador-viewer/mirador-viewer.component.ts
@@ -70,7 +70,8 @@ export class MiradorViewerComponent implements OnInit {
     const manifestApiEndpoint = encodeURIComponent(environment.rest.baseUrl + '/iiif/'
       + this.object.id + '/manifest');
     // The Express path to Mirador viewer.
-    let viewerPath = '/iiif/mirador/index.html?manifest=' + manifestApiEndpoint;
+    let viewerPath = `${environment.ui.nameSpace}${environment.ui.nameSpace.length > 1 ? '/' : ''}`
+      + `iiif/mirador/index.html?manifest=${manifestApiEndpoint}`;
     if (this.searchable) {
       // Tell the viewer add search to menu.
       viewerPath += '&searchable=' + this.searchable;


### PR DESCRIPTION
## Description
Have Mirador viewer accessible when deployed under a context path.
