### PR TITLE
Community subcommunities/collections tree navigation

### DIFF
--- a/src/app/community-list-page/community-list-service.ts
+++ b/src/app/community-list-page/community-list-service.ts
@@ -154,12 +154,11 @@ export class CommunityListService {
       return observableCombineLatest(topComs$, observableCombineLatest([...scopedCollections])).pipe(
         switchMap(([topComs, scopeCols]) => this.transformListOfCommunities(topComs, 0, null, expandedNodes).pipe(
           map((nodes: FlatNode[]) => {
-            const currentCollectionPage = scopeCols.sort((a, b) => b.currentPage - a.currentPage)[0].currentPage;
             const colNodes = scopeCols.map(payload => {
               let cNodes = payload.page.map((collection: Collection) => {
                 return toFlatNode(collection, observableOf(false), 0, false);
               });
-              if (currentCollectionPage < payload.totalPages && currentCollectionPage === payload.currentPage) {
+              if (currentPage < payload.totalPages && currentPage === payload.currentPage) {
                 cNodes = [...cNodes, showMoreFlatNode('collection', 0, null)];
               }
               return cNodes;

--- a/src/app/community-list-page/community-list-service.ts
+++ b/src/app/community-list-page/community-list-service.ts
@@ -160,7 +160,7 @@ export class CommunityListService {
                 return toFlatNode(collection, observableOf(false), 0, false);
               });
               if (currentPage < payload.totalPages && currentPage === payload.currentPage) {
-                cNodes = [...cNodes, showMoreFlatNode('collection', 0, null)];
+                cNodes = [...cNodes, showMoreFlatNode(`collection-${uuidv4()}`, 0, null)];
               }
               return cNodes;
             }).reduce((acc, e) => acc.concat(e), []);

--- a/src/app/community-list-page/community-list-service.ts
+++ b/src/app/community-list-page/community-list-service.ts
@@ -124,9 +124,18 @@ export class CommunityListService {
   loadCommunities(findOptions: FindListOptions, expandedNodes: FlatNode[]): Observable<FlatNode[]> {
     const currentPage = findOptions.currentPage;
     const topCommunities = [];
+    // TAMU Customization - gather scoped collections
+    const scopedCollections = [];
+
     for (let i = 1; i <= currentPage; i++) {
       const pagination: FindListOptions = Object.assign({}, findOptions, { currentPage: i });
       topCommunities.push(this.getTopCommunities(pagination));
+
+      // TAMU Customization - gather scoped collections
+      if (!!findOptions.scopeID) {
+        scopedCollections.push(this.getScopedCollections(pagination));
+      }
+
     }
     const topComs$ = observableCombineLatest([...topCommunities]).pipe(
       map((coms: PaginatedList<Community>[]) => {
@@ -139,6 +148,29 @@ export class CommunityListService {
         return buildPaginatedList(newPageInfo, newPage);
       })
     );
+
+    // TAMU Customization - process scoped collections
+    if (scopedCollections.length > 0) {
+      return observableCombineLatest(topComs$, observableCombineLatest([...scopedCollections])).pipe(
+        switchMap(([topComs, scopeCols]) => this.transformListOfCommunities(topComs, 0, null, expandedNodes).pipe(
+          map((nodes: FlatNode[]) => {
+            const currentCollectionPage = scopeCols.sort((a, b) => b.currentPage - a.currentPage)[0].currentPage;
+            const colNodes = scopeCols.map(payload => {
+              let cNodes = payload.page.map((collection: Collection) => {
+                return toFlatNode(collection, observableOf(false), 0, false);
+              });
+              if (currentCollectionPage < payload.totalPages && currentCollectionPage === payload.currentPage) {
+                cNodes = [...cNodes, showMoreFlatNode('collection', 0, null)];
+              }
+              return cNodes;
+            }).reduce((acc, e) => acc.concat(e), []);
+            return [...nodes, ...colNodes];
+          })
+        )),
+        // distinctUntilChanged((a: FlatNode[], b: FlatNode[]) => a.length === b.length)
+      );
+    }
+
     return topComs$.pipe(
       switchMap((topComs: PaginatedList<Community>) => this.transformListOfCommunities(topComs, 0, null, expandedNodes)),
       // distinctUntilChanged((a: FlatNode[], b: FlatNode[]) => a.length === b.length)
@@ -150,6 +182,8 @@ export class CommunityListService {
    */
   private getTopCommunities(options: FindListOptions): Observable<PaginatedList<Community>> {
     return this.communityDataService.findTop({
+        // TAMU Customization - propegate scope id
+        scopeID: options.scopeID,
         currentPage: options.currentPage,
         elementsPerPage: this.pageSize,
         sort: {
@@ -159,6 +193,26 @@ export class CommunityListService {
       },
       followLink('subcommunities', { findListOptions: this.configOnePage }),
       followLink('collections', { findListOptions: this.configOnePage }))
+      .pipe(
+        getFirstSucceededRemoteData(),
+        map((results) => results.payload),
+      );
+  }
+
+  // TAMU Customization - get scoped collections
+  /**
+   * Puts the initial scoped collections in a list to be called upon
+   */
+  private getScopedCollections(options: FindListOptions): Observable<PaginatedList<Collection>> {
+    return this.collectionDataService.findScopeCollections({
+        scopeID: options.scopeID,
+        currentPage: options.currentPage,
+        elementsPerPage: this.pageSize,
+        sort: {
+          field: options.sort.field,
+          direction: options.sort.direction
+        }
+      })
       .pipe(
         getFirstSucceededRemoteData(),
         map((results) => results.payload),

--- a/src/app/community-list-page/community-list-service.ts
+++ b/src/app/community-list-page/community-list-service.ts
@@ -167,7 +167,6 @@ export class CommunityListService {
             return [...nodes, ...colNodes];
           })
         )),
-        // distinctUntilChanged((a: FlatNode[], b: FlatNode[]) => a.length === b.length)
       );
     }
 

--- a/src/app/community-list-page/community-list-service.ts
+++ b/src/app/community-list-page/community-list-service.ts
@@ -24,6 +24,7 @@ import { FlatNode } from './flat-node.model';
 import { ShowMoreFlatNode } from './show-more-flat-node.model';
 import { FindListOptions } from '../core/data/find-list-options.model';
 import { AppConfig, APP_CONFIG } from 'src/config/app-config.interface';
+import { v4 as uuidv4 } from 'uuid';
 
 // Helper method to combine and flatten an array of observables of flatNode arrays
 export const combineAndFlatten = (obsList: Observable<FlatNode[]>[]): Observable<FlatNode[]> =>
@@ -239,7 +240,7 @@ export class CommunityListService {
           return this.transformCommunity(community, level, parent, expandedNodes);
         });
       if (currentPage < listOfPaginatedCommunities.totalPages && currentPage === listOfPaginatedCommunities.currentPage) {
-        obsList = [...obsList, observableOf([showMoreFlatNode('community', level, parent)])];
+        obsList = [...obsList, observableOf([showMoreFlatNode(`community-${uuidv4()}`, level, parent)])];
       }
 
       return combineAndFlatten(obsList);
@@ -310,7 +311,7 @@ export class CommunityListService {
                 let nodes = rd.payload.page
                   .map((collection: Collection) => toFlatNode(collection, observableOf(false), level + 1, false, communityFlatNode));
                 if (currentCollectionPage < rd.payload.totalPages && currentCollectionPage === rd.payload.currentPage) {
-                  nodes = [...nodes, showMoreFlatNode('collection', level + 1, communityFlatNode)];
+                  nodes = [...nodes, showMoreFlatNode(`collection-${uuidv4()}`, level + 1, communityFlatNode)];
                 }
                 return nodes;
               } else {

--- a/src/app/community-list-page/community-list/community-list.component.html
+++ b/src/app/community-list-page/community-list/community-list.component.html
@@ -8,7 +8,7 @@
         <span class="fa fa-chevron-right invisible" aria-hidden="true"></span>
       </button>
       <div class="align-middle pt-2">
-        <button *ngIf="node!==loadingNode" (click)="getNextPage(node)"
+        <button *ngIf="!(dataSource.loading$ | async)" (click)="getNextPage(node)"
            class="btn btn-outline-primary btn-sm" role="button">
            <i class="fas fa-angle-down"></i> {{ 'communityList.showMore' | translate }}
         </button>

--- a/src/app/community-list-page/community-list/community-list.component.spec.ts
+++ b/src/app/community-list-page/community-list/community-list.component.spec.ts
@@ -17,6 +17,7 @@ import { By } from '@angular/platform-browser';
 import { isEmpty, isNotEmpty } from '../../shared/empty.util';
 import { FlatNode } from '../flat-node.model';
 import { RouterLinkWithHref } from '@angular/router';
+import { v4 as uuidv4 } from 'uuid';
 
 describe('CommunityListComponent', () => {
   let component: CommunityListComponent;
@@ -138,7 +139,7 @@ describe('CommunityListComponent', () => {
         }
         if (expandedNodes === null || isEmpty(expandedNodes)) {
           if (showMoreTopComNode) {
-            return observableOf([...mockTopFlatnodesUnexpanded.slice(0, endPageIndex), showMoreFlatNode('community', 0, null)]);
+            return observableOf([...mockTopFlatnodesUnexpanded.slice(0, endPageIndex), showMoreFlatNode(`community-${uuidv4()}`, 0, null)]);
           } else {
             return observableOf(mockTopFlatnodesUnexpanded.slice(0, endPageIndex));
           }
@@ -165,21 +166,21 @@ describe('CommunityListComponent', () => {
                   const endSubComIndex = this.pageSize * expandedParent.currentCommunityPage;
                   flatnodes = [...flatnodes, ...subComFlatnodes.slice(0, endSubComIndex)];
                   if (subComFlatnodes.length > endSubComIndex) {
-                    flatnodes = [...flatnodes, showMoreFlatNode('community', topNode.level + 1, expandedParent)];
+                    flatnodes = [...flatnodes, showMoreFlatNode(`community-${uuidv4()}`, topNode.level + 1, expandedParent)];
                   }
                 }
                 if (isNotEmpty(collFlatnodes)) {
                   const endColIndex = this.pageSize * expandedParent.currentCollectionPage;
                   flatnodes = [...flatnodes, ...collFlatnodes.slice(0, endColIndex)];
                   if (collFlatnodes.length > endColIndex) {
-                    flatnodes = [...flatnodes, showMoreFlatNode('collection', topNode.level + 1, expandedParent)];
+                    flatnodes = [...flatnodes, showMoreFlatNode(`collection-${uuidv4()}`, topNode.level + 1, expandedParent)];
                   }
                 }
               }
             }
           });
           if (showMoreTopComNode) {
-            flatnodes = [...flatnodes, showMoreFlatNode('community', 0, null)];
+            flatnodes = [...flatnodes, showMoreFlatNode(`community-${uuidv4()}`, 0, null)];
           }
           return observableOf(flatnodes);
         }

--- a/src/app/community-list-page/community-list/community-list.component.spec.ts
+++ b/src/app/community-list-page/community-list/community-list.component.spec.ts
@@ -244,7 +244,7 @@ describe('CommunityListComponent', () => {
         preventDefault: () => {/**/
         }
       });
-      tick();
+      tick(250);
       fixture.detectChanges();
     }));
 
@@ -259,10 +259,10 @@ describe('CommunityListComponent', () => {
         })).toBeTruthy();
       });
     });
-    it('show more node is gone from end of nodetree', () => {
+    it('show more node is gone from end of nodetree', fakeAsync(() => {
       const showMoreEl = fixture.debugElement.queryAll(By.css('.show-more-node'));
       expect(showMoreEl.length).toEqual(0);
-    });
+    }));
   });
 
   describe('when first expandable node is expanded', () => {
@@ -272,7 +272,7 @@ describe('CommunityListComponent', () => {
       const chevronExpandSpan = fixture.debugElement.query(By.css('.expandable-node button span'));
       if (chevronExpandSpan.nativeElement.classList.contains('fa-chevron-right')) {
         chevronExpand.nativeElement.click();
-        tick();
+        tick(250);
         fixture.detectChanges();
       }
 
@@ -305,7 +305,7 @@ describe('CommunityListComponent', () => {
         const chevronExpandSpan = fixture.debugElement.queryAll(By.css('.expandable-node button span'));
         if (chevronExpandSpan[1].nativeElement.classList.contains('fa-chevron-right')) {
           chevronExpand[1].nativeElement.click();
-          tick();
+          tick(250);
           fixture.detectChanges();
         }
 

--- a/src/app/community-list-page/community-list/community-list.component.ts
+++ b/src/app/community-list-page/community-list/community-list.component.ts
@@ -111,19 +111,18 @@ export class CommunityListComponent implements OnInit, OnDestroy {
   getNextPage(node: FlatNode): void {
     this.loadingNode = node;
     if (node.parent != null) {
-      if (node.id === 'collection') {
+      if (node.id.startsWith('collection')) {
         const parentNodeInExpandedNodes = this.expandedNodes.find((node2: FlatNode) => node.parent.id === node2.id);
         parentNodeInExpandedNodes.currentCollectionPage++;
       }
-      if (node.id === 'community') {
+      if (node.id.startsWith('community')) {
         const parentNodeInExpandedNodes = this.expandedNodes.find((node2: FlatNode) => node.parent.id === node2.id);
         parentNodeInExpandedNodes.currentCommunityPage++;
       }
-      this.dataSource.loadCommunities(this.paginationConfig, this.expandedNodes);
     } else {
       this.paginationConfig.currentPage++;
-      this.dataSource.loadCommunities(this.paginationConfig, this.expandedNodes);
     }
+    this.dataSource.loadCommunities(this.paginationConfig, this.expandedNodes);
   }
 
 }

--- a/src/app/core/data/collection-data.service.ts
+++ b/src/app/core/data/collection-data.service.ts
@@ -55,6 +55,14 @@ export class CollectionDataService extends ComColDataService<Collection> {
     super('collections', requestService, rdbService, objectCache, halService, comparator, notificationsService, bitstreamDataService);
   }
 
+  // TAMU Customization - find scoped collections
+  findScopeCollections(options: FindListOptions = {}): Observable<RemoteData<PaginatedList<Collection>>> {
+    return this.getEndpoint().pipe(
+      map(href => this.getFindByParentHref(options.scopeID)),
+      switchMap(href => this.findListByHref(href, options, true, true))
+    );
+  }
+
   /**
    * Get all collections the user is authorized to submit to
    *

--- a/src/app/core/data/community-data.service.ts
+++ b/src/app/core/data/community-data.service.ts
@@ -43,13 +43,14 @@ export class CommunityDataService extends ComColDataService<Community> {
 
   findTop(options: FindListOptions = {}, ...linksToFollow: FollowLinkConfig<Community>[]): Observable<RemoteData<PaginatedList<Community>>> {
     return this.getEndpoint().pipe(
-      map(href => `${href}/search/top`),
+      // TAMU Customization - find by parent href if scope id provided
+      map(href => !!options.scopeID ? this.getFindByParentHref(options.scopeID) : `${href}/search/top`),
       switchMap(href => this.findListByHref(href, options, true, true, ...linksToFollow))
     );
   }
 
   protected getFindByParentHref(parentUUID: string): Observable<string> {
-    return this.halService.getEndpoint(this.linkPath).pipe(
+    return this.getEndpoint().pipe(
       switchMap((communityEndpointHref: string) =>
         this.halService.getEndpoint('subcommunities', `${communityEndpointHref}/${parentUUID}`))
     );

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5255,4 +5255,8 @@
   "theme.periodicals.browse": "Browse Issue",
 
   "theme.periodicals.complete": "Download Complete Issue",
+
+  "communityList.expandAll": "Expand All",
+
+  "communityList.collapseAll": "Collapse All",
 }

--- a/src/themes/capstone/eager-theme.module.ts
+++ b/src/themes/capstone/eager-theme.module.ts
@@ -1,11 +1,11 @@
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ItemPageModule } from '../../app/item-page/item-page.module';
 import { ItemSharedModule } from '../../app/item-page/item-shared.module';
 import { DsoPageModule } from '../../app/shared/dso-page/dso-page.module';
-import { UntypedItemComponent } from './app/item-page/simple/item-types/untyped-item/untyped-item.component';
-import { CommonModule } from '@angular/common';
-import { SharedModule } from '../../app/shared/shared.module';
 import { ResultsBackButtonModule } from '../../app/shared/results-back-button/results-back-button.module';
+import { SharedModule } from '../../app/shared/shared.module';
+import { UntypedItemComponent } from './app/item-page/simple/item-types/untyped-item/untyped-item.component';
 
 /**
  * Add components that use a custom decorator to ENTRY_COMPONENTS as well as DECLARATIONS.

--- a/src/themes/image-gallery/app/community-list-page/community-list/community-list.component.ts
+++ b/src/themes/image-gallery/app/community-list-page/community-list/community-list.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { CommunityListComponent as BaseComponent } from '../../../../tamu/app/community-list-page/community-list/community-list.component';
+
+/**
+ * A tree-structured list of nodes representing the communities, their subCommunities and collections.
+ * Initially only the page-restricted top communities are shown.
+ * Each node can be expanded to show its children and all children are also page-limited.
+ * More pages of a page-limited result can be shown by pressing a show more node/link.
+ * Which nodes were expanded is kept in the store, so this persists across pages.
+ */
+@Component({
+  selector: 'ds-community-list',
+  // styleUrls: ['./community-list.component.scss'],
+  // templateUrl: './community-list.component.html'
+  templateUrl: '../../../../../app/community-list-page/community-list/community-list.component.html'
+})
+export class CommunityListComponent extends BaseComponent {
+
+}
+

--- a/src/themes/image-gallery/app/community-page/community-page.component.html
+++ b/src/themes/image-gallery/app/community-page/community-page.component.html
@@ -34,8 +34,13 @@
         <ds-themed-comcol-page-browse-by [id]="communityPayload.id" [contentType]="communityPayload.type">
         </ds-themed-comcol-page-browse-by>
 
+        <!-- TAMU Customization - community collection tree browse -->
+        <ds-community-list [scopeId]="communityPayload.id"></ds-community-list>
+        <!--
         <ds-themed-community-page-sub-community-list [community]="communityPayload"></ds-themed-community-page-sub-community-list>
         <ds-themed-community-page-sub-collection-list [community]="communityPayload"></ds-themed-community-page-sub-collection-list>
+        -->
+        <!-- End TAMU Customization - community collection tree browse -->
 
         <!-- TAMU Customization - recent submissions grid view -->
         <ng-container *ngVar="(itemRD$ | async) as itemRD">

--- a/src/themes/image-gallery/app/community-page/community-page.component.html
+++ b/src/themes/image-gallery/app/community-page/community-page.component.html
@@ -35,7 +35,7 @@
         </ds-themed-comcol-page-browse-by>
 
         <!-- TAMU Customization - community collection tree browse -->
-        <ds-community-list [scopeId]="communityPayload.id"></ds-community-list>
+        <ds-community-list [scopeId]="communityPayload.id" [enableExpandCollapseAll]="true"></ds-community-list>
         <!--
         <ds-themed-community-page-sub-community-list [community]="communityPayload"></ds-themed-community-page-sub-community-list>
         <ds-themed-community-page-sub-collection-list [community]="communityPayload"></ds-themed-community-page-sub-collection-list>

--- a/src/themes/image-gallery/eager-theme.module.ts
+++ b/src/themes/image-gallery/eager-theme.module.ts
@@ -1,3 +1,4 @@
+import { CdkTreeModule } from '@angular/cdk/tree';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { CommunityPageModule } from '../../app/community-page/community-page.module';
@@ -10,6 +11,7 @@ import { ResultsBackButtonModule } from '../../app/shared/results-back-button/re
 import { SharedModule } from '../../app/shared/shared.module';
 import { StatisticsModule } from '../../app/statistics/statistics.module';
 import { CollectionPageComponent } from './app/collection-page/collection-page.component';
+import { CommunityListComponent } from './app/community-list-page/community-list/community-list.component';
 import { CommunityPageComponent } from './app/community-page/community-page.component';
 import { ItemGridElementComponent } from './app/shared/object-grid/item-grid-element/item-types/item/item-grid-element.component';
 import { ItemSearchResultGridElementComponent } from './app/shared/object-grid/search-result-grid-element/item-search-result/item/item-search-result-grid-element.component';
@@ -25,6 +27,7 @@ const ENTRY_COMPONENTS = [
 
 const DECLARATIONS = [
   ...ENTRY_COMPONENTS,
+  CommunityListComponent,
   ItemGridElementComponent,
   ItemSearchResultGridElementComponent,
 ];
@@ -41,6 +44,7 @@ const DECLARATIONS = [
     DsoPageModule,
     StatisticsModule,
     CommunityPageModule,
+    CdkTreeModule,
   ],
   declarations: DECLARATIONS,
   providers: [

--- a/src/themes/image-gallery/eager-theme.module.ts
+++ b/src/themes/image-gallery/eager-theme.module.ts
@@ -21,12 +21,12 @@ import { ItemSearchResultGridElementComponent } from './app/shared/object-grid/s
 const ENTRY_COMPONENTS = [
   CollectionPageComponent,
   CommunityPageComponent,
-  ItemGridElementComponent,
-  ItemSearchResultGridElementComponent,
 ];
 
 const DECLARATIONS = [
   ...ENTRY_COMPONENTS,
+  ItemGridElementComponent,
+  ItemSearchResultGridElementComponent,
 ];
 
 @NgModule({

--- a/src/themes/tamu/app/community-list-page/community-list/community-list.component.html
+++ b/src/themes/tamu/app/community-list-page/community-list/community-list.component.html
@@ -1,6 +1,6 @@
 <ds-themed-loading *ngIf="(dataSource.loading$ | async) && !loadingNode" class="ds-themed-loading"></ds-themed-loading>
 <!-- TAMU Customization - expand/collapse all -->
-<div class="row mb-1">
+<div class="row mb-1" *ngIf="enableExpandCollapseAll">
   <div class="col">
     <button (click)="expandAll()" [disabled]="(isExpanding | async)" class="btn btn-outline-primary btn-sm mr-2" role="button">
       <span>{{ 'communityList.expandAll' | translate }}</span>

--- a/src/themes/tamu/app/community-list-page/community-list/community-list.component.html
+++ b/src/themes/tamu/app/community-list-page/community-list/community-list.component.html
@@ -1,0 +1,107 @@
+<ds-themed-loading *ngIf="(dataSource.loading$ | async) && !loadingNode" class="ds-themed-loading"></ds-themed-loading>
+<!-- TAMU Customization - expand/collapse all -->
+<div class="row mb-1">
+  <div class="col">
+    <button (click)="expandAll()" [disabled]="(isExpanding | async)" class="btn btn-outline-primary btn-sm mr-2" role="button">
+      <span>{{ 'communityList.expandAll' | translate }}</span>
+    </button>
+    <button (click)="collapseAll()" [disabled]="(isExpanding | async)" class="btn btn-outline-primary btn-sm" role="button">
+      <span>{{ 'communityList.collapseAll' | translate }}</span>
+    </button>
+  </div>
+</div>
+<!-- End TAMU Customization - expand/collapse all -->
+<cdk-tree [dataSource]="dataSource" [treeControl]="treeControl" [trackBy]="trackBy">
+  <!-- This is the tree node template for show more node -->
+  <cdk-tree-node *cdkTreeNodeDef="let node; when: isShowMore" cdkTreeNodePadding
+                 class="example-tree-node show-more-node">
+    <div class="btn-group">
+      <button type="button" class="btn btn-default" cdkTreeNodeToggle>
+        <span class="fa fa-chevron-right invisible" aria-hidden="true"></span>
+      </button>
+      <div class="align-middle pt-2">
+        <button #viewMore *ngIf="!(dataSource.loading$ | async)" (click)="getNextPage(node)"
+           class="btn btn-outline-primary btn-sm" role="button">
+           <i class="fas fa-angle-down"></i> {{ 'communityList.showMore' | translate }}
+        </button>
+        <ds-themed-loading *ngIf="node===loadingNode && dataSource.loading$ | async" class="ds-themed-loading"></ds-themed-loading>
+      </div>
+    </div>
+    <div class="text-muted" cdkTreeNodePadding>
+      <div class="d-flex">
+      </div>
+    </div>
+  </cdk-tree-node>
+  <!-- This is the tree node template for expandable nodes (coms and subcoms with children) -->
+  <cdk-tree-node *cdkTreeNodeDef="let node; when: hasChild" cdkTreeNodePadding
+                 class="example-tree-node expandable-node">
+    <div class="btn-group">
+      <button #toggle type="button" class="btn btn-default" cdkTreeNodeToggle
+              [title]="'toggle ' + dsoNameService.getName(node.payload)"
+              [attr.aria-label]="'toggle ' + dsoNameService.getName(node.payload)"
+              (click)="toggleExpanded(node)"
+              [ngClass]="(hasChild(null, node)| async) ? 'visible' : 'invisible'"
+              [attr.data-test]="(hasChild(null, node)| async) ? 'expand-button' : ''">
+        <span class="{{node.isExpanded ? 'fa fa-chevron-down' : 'fa fa-chevron-right'}}"
+              aria-hidden="true"></span>
+      </button>
+      <div class="d-flex flex-row">
+        <span class="align-middle pt-2 lead">
+          <a [routerLink]="node.route" class="lead">
+            {{ dsoNameService.getName(node.payload) }}
+          </a>
+          <span class="pr-2">&nbsp;</span>
+          <span *ngIf="node.payload.archivedItemsCount >= 0" class="badge badge-pill badge-secondary align-top archived-items-lead">{{node.payload.archivedItemsCount}}</span>
+        </span>
+      </div>
+    </div>
+    <ds-truncatable [id]="node.id">
+      <div class="text-muted" cdkTreeNodePadding>
+        <div class="d-flex" *ngIf="node.payload.shortDescription">
+          <button type="button" class="btn btn-default invisible">
+            <span class="{{node.isExpanded ? 'fa fa-chevron-down' : 'fa fa-chevron-right'}}"
+                  aria-hidden="true"></span>
+          </button>
+          <ds-truncatable-part [id]="node.id" [minLines]="3">
+            <span>{{node.payload.shortDescription}}</span>
+          </ds-truncatable-part>
+        </div>
+      </div>
+    </ds-truncatable>
+    <div class="d-flex" *ngIf="node===loadingNode && dataSource.loading$ | async"
+         cdkTreeNodePadding>
+      <button type="button" class="btn btn-default invisible">
+        <span class="{{node.isExpanded ? 'fa fa-chevron-down' : 'fa fa-chevron-right'}}"
+              aria-hidden="true"></span>
+      </button>
+      <ds-themed-loading class="ds-themed-loading"></ds-themed-loading>
+    </div>
+  </cdk-tree-node>
+  <!-- This is the tree node template for leaf nodes (collections and (sub)coms without children) -->
+  <cdk-tree-node *cdkTreeNodeDef="let node; when: !(hasChild && isShowMore)" cdkTreeNodePadding
+                 class="example-tree-node childless-node">
+    <div class="btn-group">
+      <button type="button" class="btn btn-default" cdkTreeNodeToggle>
+        <span class="fa fa-chevron-right invisible" aria-hidden="true"></span>
+      </button>
+      <h6 class="align-middle pt-2">
+        <a [routerLink]="node.route" class="lead">
+          {{ dsoNameService.getName(node.payload) }}
+        </a>
+      </h6>
+    </div>
+    <ds-truncatable [id]="node.id">
+      <div class="text-muted" cdkTreeNodePadding>
+        <div class="d-flex" *ngIf="node.payload.shortDescription">
+          <button type="button" class="btn btn-default invisible">
+            <span class="{{node.isExpanded ? 'fa fa-chevron-down' : 'fa fa-chevron-right'}}"
+                  aria-hidden="true"></span>
+          </button>
+          <ds-truncatable-part [id]="node.id" [minLines]="3">
+            <span>{{node.payload.shortDescription}}</span>
+          </ds-truncatable-part>
+        </div>
+      </div>
+    </ds-truncatable>
+  </cdk-tree-node>
+</cdk-tree>

--- a/src/themes/tamu/app/community-list-page/community-list/community-list.component.ts
+++ b/src/themes/tamu/app/community-list-page/community-list/community-list.component.ts
@@ -36,9 +36,14 @@ export class CommunityListComponent extends BaseComponent implements OnInit {
     let anyExpanded = false;
     this.isExpanding.next(true);
 
+    const expandable = this.toggle.filter((node: any) => {
+      return !!node.nativeElement.querySelector('.fa-chevron-right');
+    });
+
     this.dataSource.loading$.pipe(
       distinctUntilChanged(),
-      debounceTime(500),
+      // allow 100 milliseconds per expanded subcommunity
+      debounceTime(expandable.length * 100),
       take(1)
     ).subscribe(() => {
       if (anyExpanded) {
@@ -48,9 +53,7 @@ export class CommunityListComponent extends BaseComponent implements OnInit {
       }
     });
 
-    this.toggle.filter((node: any) => {
-      return !!node.nativeElement.querySelector('.fa-chevron-right');
-    }).forEach((node: any) => {
+    expandable.forEach((node: any) => {
       node.nativeElement.click();
       if (!anyExpanded) {
         anyExpanded = true;

--- a/src/themes/tamu/app/community-list-page/community-list/community-list.component.ts
+++ b/src/themes/tamu/app/community-list-page/community-list/community-list.component.ts
@@ -1,0 +1,27 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { CommunityListComponent as BaseComponent } from '../../../../../app/community-list-page/community-list/community-list.component';
+
+/**
+ * A tree-structured list of nodes representing the communities, their subCommunities and collections.
+ * Initially only the page-restricted top communities are shown.
+ * Each node can be expanded to show its children and all children are also page-limited.
+ * More pages of a page-limited result can be shown by pressing a show more node/link.
+ * Which nodes were expanded is kept in the store, so this persists across pages.
+ */
+@Component({
+  selector: 'ds-community-list',
+  // styleUrls: ['./community-list.component.scss'],
+  // templateUrl: './community-list.component.html'
+  templateUrl: '../../../../../app/community-list-page/community-list/community-list.component.html'
+})
+export class CommunityListComponent extends BaseComponent implements OnInit {
+
+  @Input() scopeId!: string;
+
+  ngOnInit(): void {
+    this.paginationConfig.scopeID = this.scopeId;
+    super.ngOnInit();
+  }
+
+}
+

--- a/src/themes/tamu/app/community-list-page/community-list/community-list.component.ts
+++ b/src/themes/tamu/app/community-list-page/community-list/community-list.component.ts
@@ -20,6 +20,8 @@ export class CommunityListComponent extends BaseComponent implements OnInit {
 
   @Input() scopeId!: string;
 
+  @Input() enableExpandCollapseAll = false;
+
   @ViewChildren('toggle') toggle!: QueryList<any>;
 
   isExpanding: BehaviorSubject<boolean>;

--- a/src/themes/tamu/app/community-page/community-page.component.html
+++ b/src/themes/tamu/app/community-page/community-page.component.html
@@ -1,0 +1,44 @@
+<div class="container" *ngVar="(communityRD$ | async) as communityRD">
+  <div class="community-page" *ngIf="communityRD?.hasSucceeded" @fadeInOut>
+    <div *ngIf="communityRD?.payload; let communityPayload">
+      <ds-view-tracker [object]="communityPayload"></ds-view-tracker>
+      <div class="d-flex flex-row border-bottom mb-4 pb-4">
+        <header class="comcol-header mr-auto">
+          <!-- Community name -->
+          <ds-comcol-page-header [name]="dsoNameService.getName(communityPayload)"></ds-comcol-page-header>
+          <!-- Community logo -->
+          <ds-comcol-page-logo *ngIf="logoRD$" [logo]="(logoRD$ | async)?.payload" [alternateText]="'Community Logo'">
+          </ds-comcol-page-logo>
+          <!-- Handle -->
+          <ds-themed-comcol-page-handle [content]="communityPayload.handle" [title]="'community.page.handle'">
+          </ds-themed-comcol-page-handle>
+          <!-- Introductory text -->
+          <ds-comcol-page-content [content]="communityPayload.introductoryText" [hasInnerHtml]="true">
+          </ds-comcol-page-content>
+          <!-- News -->
+          <ds-comcol-page-content [content]="communityPayload.sidebarText" [hasInnerHtml]="true"
+            [title]="'community.page.news'">
+          </ds-comcol-page-content>
+        </header>
+        <ds-dso-edit-menu></ds-dso-edit-menu>
+      </div>
+      <section class="comcol-page-browse-section">
+
+        <!-- Browse-By Links -->
+        <ds-themed-comcol-page-browse-by [id]="communityPayload.id" [contentType]="communityPayload.type">
+        </ds-themed-comcol-page-browse-by>
+
+        <ds-themed-community-page-sub-community-list [community]="communityPayload"></ds-themed-community-page-sub-community-list>
+        <ds-themed-community-page-sub-collection-list [community]="communityPayload"></ds-themed-community-page-sub-collection-list>
+      </section>
+      <footer  *ngIf="communityPayload.copyrightText"  class="border-top my-5 pt-4">
+        <!-- Copyright -->
+        <ds-comcol-page-content [content]="communityPayload.copyrightText" [hasInnerHtml]="true">
+        </ds-comcol-page-content>
+      </footer>
+    </div>
+  </div>
+
+  <ds-error *ngIf="communityRD?.hasFailed" message="{{'error.community' | translate}}"></ds-error>
+  <ds-themed-loading *ngIf="communityRD?.isLoading" message="{{'loading.community' | translate}}"></ds-themed-loading>
+</div>

--- a/src/themes/tamu/app/community-page/community-page.component.html
+++ b/src/themes/tamu/app/community-page/community-page.component.html
@@ -28,8 +28,13 @@
         <ds-themed-comcol-page-browse-by [id]="communityPayload.id" [contentType]="communityPayload.type">
         </ds-themed-comcol-page-browse-by>
 
+        <!-- TAMU Customization - community collection tree browse -->
+        <ds-community-list [scopeId]="communityPayload.id"></ds-community-list>
+        <!--
         <ds-themed-community-page-sub-community-list [community]="communityPayload"></ds-themed-community-page-sub-community-list>
         <ds-themed-community-page-sub-collection-list [community]="communityPayload"></ds-themed-community-page-sub-collection-list>
+        -->
+        <!-- End TAMU Customization - community collection tree browse -->
       </section>
       <footer  *ngIf="communityPayload.copyrightText"  class="border-top my-5 pt-4">
         <!-- Copyright -->

--- a/src/themes/tamu/app/community-page/community-page.component.html
+++ b/src/themes/tamu/app/community-page/community-page.component.html
@@ -29,7 +29,7 @@
         </ds-themed-comcol-page-browse-by>
 
         <!-- TAMU Customization - community collection tree browse -->
-        <ds-community-list [scopeId]="communityPayload.id"></ds-community-list>
+        <ds-community-list [scopeId]="communityPayload.id" [enableExpandCollapseAll]="true"></ds-community-list>
         <!--
         <ds-themed-community-page-sub-community-list [community]="communityPayload"></ds-themed-community-page-sub-community-list>
         <ds-themed-community-page-sub-collection-list [community]="communityPayload"></ds-themed-community-page-sub-collection-list>

--- a/src/themes/tamu/app/community-page/community-page.component.ts
+++ b/src/themes/tamu/app/community-page/community-page.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommunityPageComponent as BaseComponent } from '../../../../app/community-page/community-page.component';
+import { fadeInOut } from '../../../../app/shared/animations/fade';
+
+@Component({
+  selector: 'ds-community-page',
+  templateUrl: './community-page.component.html',
+  // templateUrl: '../../../../app/community-page/community-page.component.html',
+  // styleUrls: ['./community-page.component.scss'],
+  styleUrls: ['../../../../app/community-page/community-page.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  animations: [fadeInOut]
+})
+/**
+ * This component represents a detail page for a single community
+ */
+export class CommunityPageComponent extends BaseComponent {
+  
+}

--- a/src/themes/tamu/app/community-page/community-page.component.ts
+++ b/src/themes/tamu/app/community-page/community-page.component.ts
@@ -15,5 +15,5 @@ import { fadeInOut } from '../../../../app/shared/animations/fade';
  * This component represents a detail page for a single community
  */
 export class CommunityPageComponent extends BaseComponent {
-  
+
 }

--- a/src/themes/tamu/assets/i18n/en.json5
+++ b/src/themes/tamu/assets/i18n/en.json5
@@ -15,4 +15,8 @@
 
   "login.form.header": "Please log in to OAKTrust",
 
+  "communityList.expandAll": "Expand All",
+
+  "communityList.collapseAll": "Collapse All",
+
 }

--- a/src/themes/tamu/eager-theme.module.ts
+++ b/src/themes/tamu/eager-theme.module.ts
@@ -1,5 +1,7 @@
+import { CdkTreeModule } from '@angular/cdk/tree';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { CommunityListService } from '../../app/community-list-page/community-list-service';
 import { CommunityPageModule } from '../../app/community-page/community-page.module';
 import { NavbarModule } from '../../app/navbar/navbar.module';
 import { RootModule } from '../../app/root.module';
@@ -9,6 +11,7 @@ import { DsoPageModule } from '../../app/shared/dso-page/dso-page.module';
 import { ResultsBackButtonModule } from '../../app/shared/results-back-button/results-back-button.module';
 import { SharedModule } from '../../app/shared/shared.module';
 import { StatisticsModule } from '../../app/statistics/statistics.module';
+import { CommunityListComponent } from './app/community-list-page/community-list/community-list.component';
 import { CommunityPageComponent } from './app/community-page/community-page.component';
 import { HeaderNavbarWrapperComponent } from './app/header-nav-wrapper/header-navbar-wrapper.component';
 import { HeaderComponent } from './app/header/header.component';
@@ -25,6 +28,7 @@ const ENTRY_COMPONENTS = [
 
 const DECLARATIONS = [
   ...ENTRY_COMPONENTS,
+  CommunityListComponent,
   HomeNewsComponent,
   HeaderComponent,
   HeaderNavbarWrapperComponent,
@@ -43,10 +47,12 @@ const DECLARATIONS = [
     DsoPageModule,
     StatisticsModule,
     CommunityPageModule,
+    CdkTreeModule,
   ],
   declarations: DECLARATIONS,
   providers: [
-    ...ENTRY_COMPONENTS.map((component) => ({provide: component}))
+    ...ENTRY_COMPONENTS.map((component) => ({provide: component})),
+    CommunityListService,
   ],
 })
 /**

--- a/src/themes/tamu/eager-theme.module.ts
+++ b/src/themes/tamu/eager-theme.module.ts
@@ -1,20 +1,27 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { CommunityPageModule } from '../../app/community-page/community-page.module';
+import { NavbarModule } from '../../app/navbar/navbar.module';
+import { RootModule } from '../../app/root.module';
+import { SharedBrowseByModule } from '../../app/shared/browse-by/shared-browse-by.module';
+import { ComcolModule } from '../../app/shared/comcol/comcol.module';
+import { DsoPageModule } from '../../app/shared/dso-page/dso-page.module';
+import { ResultsBackButtonModule } from '../../app/shared/results-back-button/results-back-button.module';
 import { SharedModule } from '../../app/shared/shared.module';
+import { StatisticsModule } from '../../app/statistics/statistics.module';
+import { CommunityPageComponent } from './app/community-page/community-page.component';
+import { HeaderNavbarWrapperComponent } from './app/header-nav-wrapper/header-navbar-wrapper.component';
+import { HeaderComponent } from './app/header/header.component';
 import { HomeNewsComponent } from './app/home-page/home-news/home-news.component';
 import { NavbarComponent } from './app/navbar/navbar.component';
-import { HeaderComponent } from './app/header/header.component';
-import { HeaderNavbarWrapperComponent } from './app/header-nav-wrapper/header-navbar-wrapper.component';
-import { RootModule } from '../../app/root.module';
-import { NavbarModule } from '../../app/navbar/navbar.module';
-import { SharedBrowseByModule } from '../../app/shared/browse-by/shared-browse-by.module';
-import { ResultsBackButtonModule } from '../../app/shared/results-back-button/results-back-button.module';
 
 /**
  * Add components that use a custom decorator to ENTRY_COMPONENTS as well as DECLARATIONS.
  * This will ensure that decorator gets picked up when the app loads
  */
-const ENTRY_COMPONENTS = [];
+const ENTRY_COMPONENTS = [
+  CommunityPageComponent
+];
 
 const DECLARATIONS = [
   ...ENTRY_COMPONENTS,
@@ -32,6 +39,10 @@ const DECLARATIONS = [
     ResultsBackButtonModule,
     RootModule,
     NavbarModule,
+    ComcolModule,
+    DsoPageModule,
+    StatisticsModule,
+    CommunityPageModule,
   ],
   declarations: DECLARATIONS,
   providers: [


### PR DESCRIPTION
## References
Resolves #14 

## Description

Add theme override to community list component providing ability to scope to a community and afford expand/collapse all. Replace subcommunities/collection paginated lists with this tree component in a theme community page override. Also, applies override to the image-gallery theme.

During development bugs were discovered in community list service and component that resulted in an [upstream PR](https://github.com/DSpace/dspace-angular/pull/2597) with same commits in this PR. Unfortunately, some changes in core code were required and have been commented as TAMU customizations.

I have asked @tdonohue if there is interest by the community for the ability to scope the community list (tree) component. He said there is a good chance others would like the feature of a community tree browser at the community level to avoid having to load entire community/collection paths to navigate. This somewhat justifies the core code changes and we may be able to contribute upstream.

![image](https://github.com/TAMULib/dspace-angular/assets/144841721/196e3fb3-d7e0-45ae-8c75-51c787e775fa)

![image](https://github.com/TAMULib/dspace-angular/assets/144841721/7e89f524-a82f-4361-8333-0269406f3f7a)

## Instructions for Reviewers

Configure `dspace-angular` to point to dev environment DSpace REST API with `config.dev.yml` such as:

```
rest:
  ssl: true
  host: api-dev.library.tamu.edu
  port: 443
  nameSpace: /dspace7
```

Navigate to Communities & Collection page and to various communities. Expand/collapse the tree individually and using the expand/collapse all buttons.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
