### PR TITLE
Data@TAMU Issue #104: Use simple item view element for co-principal investigator, update styles and i18n labels

### DIFF
--- a/src/themes/rdc/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/themes/rdc/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -39,22 +39,26 @@
       [parentItem]="object"
       [itemType]="'Person'"
       [metadataFields]="['dc.creator.pi']"
-      [label]="'Principal Investigator'">
+      [label]="'item.page.principal-investigators' | translate">
     </ds-themed-metadata-representation-list>
     <!-- END TAMU Customization - Principal Investigator  -->
-    <!-- TAMU Customization - Co Principal Investigator -->
-    <ds-themed-metadata-representation-list class="ds-item-page-mixed-author-field"
-      [parentItem]="object"
-      [itemType]="'Person'"
-      [metadataFields]="['dc.creator.copi']"
-      [label]="'Co-Principal Investigator(s)'">
-    </ds-themed-metadata-representation-list>
-    <!-- END TAMU Customization - Co Principal Investigator -->
+    <!-- TAMU Customization - Co-Principal Investigator -->
+    <div class="simple-item-view-element" *ngIf="object.allMetadata('dc.creator.copi'); let copis">
+      <h2 class="simple-view-element-header fs-4">{{"item.page.co-principal-investigators" | translate}}</h2>
+      <div class="mb-2">
+        <ul class="list-unstyled">
+          <li *ngFor="let copi of copis">
+            <span>{{copi.value}}</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <!-- END TAMU Customization - Co-Principal Investigator -->
     <!-- TAMU Customization - Department  -->
     <ds-themed-metadata-representation-list class="ds-item-page-mixed-author-field"
       [parentItem]="object"
       [metadataFields]="['dc.contributor.department']"
-      [label]="'Department'">
+      [label]="'item.page.department' | translate">
     </ds-themed-metadata-representation-list>
     <!-- END TAMU Customization - Department  -->
     <ds-generic-item-page-field [item]="object"
@@ -132,7 +136,7 @@
       <h2 class="simple-view-element-header fs-4">{{"item.page.associated-datasets" | translate}}</h2>
       <div *ngIf="getDatasets(object); let datasets">
         <div>
-          <ul>
+          <ul class="list-unstyled">
             <li *ngFor="let dataset of datasets">
               <a href="{{dataset.link}}">
                 {{dataset.title}}
@@ -147,7 +151,7 @@
     <div class="simple-item-view-element" *ngIf="object.allMetadata('dc.relation.associatedPublicationURI'); let uris">
       <h2 class="simple-view-element-header fs-4">{{"item.page.associated-publications" | translate}}</h2>
       <div class="mb-2" class="uri-truncate">
-        <ul>
+        <ul class="list-unstyled">
           <li *ngFor="let uri of uris">
             <a href="{{uri.value}}" class="uri-truncate">
               {{uri.value}}

--- a/src/themes/rdc/app/item-page/simple/item-types/untyped-item/untyped-item.component.scss
+++ b/src/themes/rdc/app/item-page/simple/item-types/untyped-item/untyped-item.component.scss
@@ -3,6 +3,10 @@
 :host {
   display: block;
 
+  .simple-item-view-element {
+    margin-bottom: 15px;
+  }
+
   .truncate-container {
     position: relative;
     width: 100%;

--- a/src/themes/rdc/assets/i18n/en.json5
+++ b/src/themes/rdc/assets/i18n/en.json5
@@ -5,6 +5,12 @@
 
   "item.page.associated-publications": "Associated Publications",
 
+  "item.page.co-principal-investigators": "Co-Principal Investigators",
+
+  "item.page.department": "Department",
+
+  "item.page.principal-investigators": "Principal Investigators",
+
   "item.page.research-project": "Research Project",
 
   "item.page.source": "Access at repository",


### PR DESCRIPTION
This PR is resolving an unintended behavior of the co-principal investigator field becoming a browse link in the simple item view.

Includes styling and i18n labels added for consistency.