### PR TITLE
Add department browse key

### DIFF
--- a/src/themes/tamu/assets/i18n/en.json5
+++ b/src/themes/tamu/assets/i18n/en.json5
@@ -61,6 +61,8 @@
 
   "browse.metadata.type": " Type",
 
+  "browse.metadata.department": " Department",
+
   "browse.metadata.department.breadcrumbs": "Browse by Department",
 
   "browse.metadata.type.breadcrumbs": "Browse by Type",


### PR DESCRIPTION
Adds a missing department browse key to the i18n config.

Before:
![Screenshot 2025-04-10 163613](https://github.com/user-attachments/assets/2dca5ea6-f6e4-45e0-b730-68d054703404)

After:
![Screenshot 2025-04-10 163628](https://github.com/user-attachments/assets/9a441b7b-638b-43f6-98e9-347839e2068b)
