### PR TITLE
Add placeholder i18n key for and themed starts with component

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -870,13 +870,15 @@
 
   "browse.startsWith.months.september": "September",
 
+  "browse.startsWith.placeholder": "Enter the first few letters.",
+
   "browse.startsWith.submit": "Browse",
 
   "browse.startsWith.type_date": "Filter results by date",
 
   "browse.startsWith.type_date.label": "Or type in a date (year-month) and click on the Browse button",
 
-  "browse.startsWith.type_text": "Filter results by typing the first few letters",
+  "browse.startsWith.type_text": "Enter the first few letters to jump to a point in the index. To instead do a general search, click <a href=\"/search\">here</a>.",
 
   "browse.startsWith.input": "Filter",
 
@@ -5366,5 +5368,5 @@
 
   "process.overview.unknown.user": "Unknown",
 
-  "browse.search-form.placeholder": "Search the repository",
+  "browse.search-form.placeholder": "Search the repository"
 }

--- a/src/themes/rdc/app/shared/starts-with/text/starts-with-text.component.html
+++ b/src/themes/rdc/app/shared/starts-with/text/starts-with-text.component.html
@@ -1,0 +1,13 @@
+<form class="w-100" [formGroup]="formData" (ngSubmit)="submitForm(formData.value)">
+  <div class="mb-3">
+    <div class="row">
+      <div class="form-group input-group col-sm-12 col-md-6 col-auto">
+        <input class="form-control" [attr.aria-label]="'browse.startsWith.input' | translate" placeholder="{{'browse.startsWith.placeholder' | translate}}" type="text" name="startsWith" formControlName="startsWith" [value]="getStartsWith()" />
+        <span class="input-group-append">
+          <button class="btn btn-primary" type="submit"><i class="fas fa-book-open"></i> {{'browse.startsWith.submit' | translate}}</button>
+        </span>
+      </div>
+    </div>
+    <small class="text-muted" innerHTML="{{'browse.startsWith.type_text' | translate}}"></small>
+  </div>
+</form>

--- a/src/themes/rdc/app/shared/starts-with/text/starts-with-text.component.ts
+++ b/src/themes/rdc/app/shared/starts-with/text/starts-with-text.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+import { renderStartsWithFor, StartsWithType } from '../../../../../../app/shared/starts-with/starts-with-decorator';
+import {
+  StartsWithTextComponent as BaseComponent
+} from '../../../../../../app/shared/starts-with/text/starts-with-text.component';
+
+@Component({
+  selector: 'ds-starts-with-text',
+  // styleUrls: ['./starts-with-text.component.scss'],
+  styleUrls: ['../../../../../../app/shared/starts-with/text/starts-with-text.component.scss'],
+  templateUrl: './starts-with-text.component.html',
+  // templateUrl: '../../../../../../app/shared/starts-with/text/starts-with-text.component.html',
+})
+@renderStartsWithFor(StartsWithType.text)
+export class StartsWithTextComponent extends BaseComponent {
+}

--- a/src/themes/rdc/eager-theme.module.ts
+++ b/src/themes/rdc/eager-theme.module.ts
@@ -13,6 +13,7 @@ import { RdcDSONameService } from './app/core/breadcrumbs/rdc-dso-name.service';
 import { RdcItemPageAbstractFieldComponent } from './app/item-page/simple/field-components/specific-field/abstract/rdc-item-page-abstract-field.component';
 import { UntypedItemComponent } from './app/item-page/simple/item-types/untyped-item/untyped-item.component';
 import { ComcolPageBrowseByComponent } from './app/shared/comcol-page-browse-by/comcol-page-browse-by.component';
+import { StartsWithTextComponent } from './app/shared/starts-with/text/starts-with-text.component';
 
 /**
  * Add components that use a custom decorator to ENTRY_COMPONENTS as well as DECLARATIONS.
@@ -21,6 +22,7 @@ import { ComcolPageBrowseByComponent } from './app/shared/comcol-page-browse-by/
 const ENTRY_COMPONENTS = [
   ComcolPageBrowseByComponent,
   RdcItemPageAbstractFieldComponent,
+  StartsWithTextComponent,
   UntypedItemComponent
 ];
 


### PR DESCRIPTION
Updates correspond to requirement of changing input field placeholder text for browse by views and not change the placeholder in the search input field.

Additionally, render `browse.startsWith.type_text` i18n corresponding to the input field hint underneath as HTML to satisfy requirement of linking to search view.

Could have conflicts with attempts to normalize component i18n key isolation, https://github.com/DSpace/dspace-angular/compare/main...TAMULib:dspace-angular:startsWith-placeholder?expand=1.

Pending discussion with community as to whether to reword UI labels and if not, why add another key with the same value?

## References

* Resolves TAMULib/data-dspace-angular#6

## Description
Theme starts with text component used in browse by views with necessary changes to adjust the label independently and to render a link in the hint text underneath.

## Instructions for Reviewers
Check search forms to ensure they have the same label as before whereas the browse by input fields (not date selectors) now have placeholder `Enter the first few letters.` and hint `Enter the first few letters to jump to a point in the index. To instead do a general search, click <a href=\"/search\">here</a>.`.

List of changes in this PR:
* Browse by text inputs should render `Enter the first few letters.`
* Second, Browse by text inputs should have hint below render `Enter the first few letters to jump to a point in the index. To instead do a general search, click <a href=\"/search\">here</a>.`

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
