### PR TITLE
Issue #203: Use `keydown` event to invoke `toggleExpanded` before `cdkTreeNodeToggle` setting its element to `tabindex` 0

### DIFF
--- a/src/themes/tamu/app/community-list-page/community-list/community-list.component.html
+++ b/src/themes/tamu/app/community-list-page/community-list/community-list.component.html
@@ -55,8 +55,8 @@
         <button #toggle type="button" class="btn btn-default btn-transparent" cdkTreeNodeToggle
           [attr.aria-label]="(node.isExpanded ? 'communityList.collapse' : 'communityList.expand') | translate:{ name: dsoNameService.getName(node.payload) }"
           (click)="toggleExpanded(node)"
-          (keyup.enter)="toggleExpanded(node)"
-          (keyup.space)="toggleExpanded(node)"
+          (keydown.enter)="toggleExpanded(node)"
+          (keydown.space)="toggleExpanded(node)"
           data-test="expand-button"
           role="button"
           tabindex="0">


### PR DESCRIPTION
## References

* Fixes #203 

## Description

Correct order of events in which the select handler to asynchronously fetch the subcommunities and collections of the given community or subcommunity if invoked before the cdk tree node invoked it's handler which switches the tabindex of the parent element from -1 to 0.  This prevents the race condition in which the parent element would be focused preventing the invocation of the expand button handler.

## Instructions for Reviewers

Test key navigation expanding and collapsing the community collection tree browser.

List of changes in this PR:
* First, switch `keydown` to `keyup` for the key event to toggle expandable node. 

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [ ] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
