### PR TITLE
Issue #214: Customize browse by starts with component form for accessibility

### DIFF
--- a/src/themes/tamu/app/shared/starts-with/text/starts-with-text.component.html
+++ b/src/themes/tamu/app/shared/starts-with/text/starts-with-text.component.html
@@ -1,0 +1,17 @@
+<form class="w-100" [formGroup]="formData" (ngSubmit)="submitForm(formData.value)">
+  <div class="mb-3">
+    <div class="row">
+      <div class="form-group input-group col-sm-12 col-md-6 col-auto">
+        <input class="form-control" [attr.aria-label]="'browse.startsWith.input' | translate" placeholder="{{'browse.startsWith.placeholder' | translate}}" type="text" name="startsWith" formControlName="startsWith" [value]="getStartsWith()" />
+        <span class="input-group-append">
+          <button class="btn btn-primary" type="submit"><i class="fas fa-book-open"></i> {{'browse.startsWith.submit' | translate}}</button>
+        </span>
+      </div>
+    </div>
+    <small class="text-muted">
+      <span aria-hidden="true">{{'browse.startsWith.input' | translate}}. </span>
+      <span aria-hidden="true">{{'browse.startsWith.click_here' | translate}}</span>
+      <span><a [attr.aria-label]="'browse.startsWith.type_text' | translate" [routerLink]="['../../search']">{{'browse.startsWith.general_search' | translate}}</a>.</span>
+    </small>
+  </div>
+</form>

--- a/src/themes/tamu/app/shared/starts-with/text/starts-with-text.component.ts
+++ b/src/themes/tamu/app/shared/starts-with/text/starts-with-text.component.ts
@@ -1,0 +1,34 @@
+import { Component } from '@angular/core';
+import {
+  FormsModule,
+  ReactiveFormsModule,
+} from '@angular/forms';
+// TAMU Customizations
+import { RouterLink } from '@angular/router';
+// END TAMU Customizations
+import { TranslateModule } from '@ngx-translate/core';
+
+import { StartsWithTextComponent as BaseComponent } from '../../../../../../app/shared/starts-with/text/starts-with-text.component';
+import { StartsWithType } from '../../../../../../app/shared/starts-with/starts-with-type';
+import { renderStartsWithFor } from '../../../../../../app/shared/starts-with/starts-with-decorator';
+
+
+@Component({
+  selector: 'ds-starts-with-text',
+  // styleUrls: ['./starts-with-text.component.scss'],
+  styleUrls: ['../../../../../../app/shared/starts-with/text/starts-with-text.component.scss'],
+  templateUrl: './starts-with-text.component.html',
+  // templateUrl: '../../../../../../app/shared/starts-with/text/starts-with-text.component.html',
+  standalone: true,
+  imports: [
+    FormsModule,
+    ReactiveFormsModule,
+    // TAMU Customizations
+    RouterLink,
+    // END TAMU Customizations
+    TranslateModule,
+  ],
+})
+@renderStartsWithFor(StartsWithType.text)
+export class StartsWithTextComponent extends BaseComponent {
+}

--- a/src/themes/tamu/assets/i18n/en.json5
+++ b/src/themes/tamu/assets/i18n/en.json5
@@ -78,4 +78,11 @@
   "nav.mydspace": "My OAKTrust",
 
   "register-page.registration.info": "Register an account to subscribe to collections for email updates, and submit new items to OAKTrust.",
+
+  "browse.startsWith.input": "To browse a location in the index, enter the first few letters",
+  "browse.startsWith.click_here": "Click here for a ",
+  "browse.startsWith.general_search": "general search",
+  "browse.startsWith.type_text": "Click here for a general search",
+
+  "browse.startsWith.placeholder": "Enter the first few letters",
 }

--- a/src/themes/tamu/eager-theme.module.ts
+++ b/src/themes/tamu/eager-theme.module.ts
@@ -13,6 +13,7 @@ import { LogoutPageComponent } from './app/logout-page/logout-page.component';
 import { CommunityListComponent } from './app/community-list-page/community-list/community-list.component';
 import { CommunityPageSubCollectionListComponent } from './app/community-page/sections/sub-com-col-section/sub-collection-list/community-page-sub-collection-list.component';
 import { CommunityPageSubCommunityListComponent } from './app/community-page/sections/sub-com-col-section/sub-community-list/community-page-sub-community-list.component';
+import { StartsWithTextComponent } from './app/shared/starts-with/text/starts-with-text.component';
 import { SubmissionSectionLicenseComponent } from './app/submission/sections/license/section-license.component';
 // END TAMU Customizations
 
@@ -34,6 +35,7 @@ const DECLARATIONS = [
   CommunityPageSubCommunityListComponent,
   LoginPageComponent,
   LogoutPageComponent,
+  StartsWithTextComponent,
   SubmissionSectionLicenseComponent,
   // END TAMU Customizations
 ];


### PR DESCRIPTION
## References

* Fixes #214 

## Description

This PR is to improve the screen reading of the browse by starts with input and hint.

## Instructions for Reviewers

~This change can be tested at https://oaktrust-dev.library.tamu.edu/browse/author.~

Please use a screen reader to test while focus on the starts with input field within the browse by views.

List of changes in this PR:
* First, add `tamu` theme i18n variables.
* Second, add `aria-label` to the starts with input box to read on focus.
* Third,  add `aria-hidden` to hint text not relevant to the link to discovery.

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
