### PR TITLE
Issue #214: Browse by text screen reader improvements

### DIFF
--- a/src/themes/tamu/app/shared/starts-with/text/starts-with-text.component.html
+++ b/src/themes/tamu/app/shared/starts-with/text/starts-with-text.component.html
@@ -9,7 +9,7 @@
       </div>
     </div>
     <small class="text-muted">
-      <span aria-hidden="true">{{'browse.startsWith.input' | translate}}. </span>
+      <span aria-hidden="true">{{'browse.startsWith.hint' | translate}}. </span>
       <span aria-hidden="true">{{'browse.startsWith.click_here' | translate}}</span>
       <span><a [attr.aria-label]="'browse.startsWith.type_text' | translate" [routerLink]="['../../search']">{{'browse.startsWith.general_search' | translate}}</a>.</span>
     </small>

--- a/src/themes/tamu/assets/i18n/en.json5
+++ b/src/themes/tamu/assets/i18n/en.json5
@@ -82,9 +82,15 @@
   "search-page.heading": "Search OAKTrust",
 
   "search-page.configuration.heading": "Search Configuration",
-  "browse.startsWith.input": "To browse a location in the index, enter the first few letters",
+
+  "browse.startsWith.input": "To browse a location in the index",
+
+  "browse.startsWith.hint": "To browse a location in the index, enter the first few letters",
+
   "browse.startsWith.click_here": "Click here for a ",
+
   "browse.startsWith.general_search": "general search",
+
   "browse.startsWith.type_text": "Click here for a general search",
 
   "browse.startsWith.placeholder": "Enter the first few letters",


### PR DESCRIPTION
When selecting on the text form input the screen reader will say "Main landmark. To browse a location in the index edit enter the first few letters blank." I am not sure what to do about it saying main landmark, edit, and blank but it is less annoying than repeating "enter the first few letters."